### PR TITLE
Add ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+language: cpp
+compiler: g++
+sudo: required
+
+matrix:
+  include:
+    - os: linux
+      dist: xenial
+    - os: linux
+      dist: bionic
+
+addopns:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - cmake
+      - libopenmpi-dev
+      - openmpi-bin
+      - openmpi-common
+
+before_install:
+  - sudo apt-get -qq update
+  - test -n $CXX && unset CXX
+
+install:
+  - sudo apt-get install -y g++-9
+
+script:
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
+  - cmake -DSIMPLEMR_BUILD_TEST=ON .
+  - make VERBOSE=1 -j
+  - ctest -VV
+
+branches:
+  only:
+    - dev
+    - master
+
+notifications:
+  email:
+    on_success: never

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The directory is structured as following.
 ## <a name="2-setup"></a>2 Setup
 ### 2.1 Install dependencies
 
-This needs to install `cmake`, `g++ (>=8)` and `mpi`.
+This needs to install `cmake`, `g++ (>=9)` and `mpi`.
 (In this project, `OPEN_MPI` is used.)
 
 If use `open-mpi`, run the following command,

--- a/tests/test_queue.cc
+++ b/tests/test_queue.cc
@@ -124,7 +124,7 @@ TEST_CASE("MessageQueue with threads", "[mq][threads]")
 
   unsigned int sum = 0;
 
-  for (unsigned int i = 0; i < 10; ++i)
+  for (unsigned int i = 0; i < 2; ++i)
   {
     threads.emplace_back([&mq](int num){
       /// Each thread pushes a pair 10 times


### PR DESCRIPTION
Add travis CI to automate testing. g++-8 raises std::bad_alloc error and could not make link with std::filesystem on Bionic in travis server so that changed g++ version to >=9. 